### PR TITLE
Remove some test compiler flags and bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val extra = project.in(file("extra"))
     libraryDependencies += "com.github.pathikrit" %% "better-files" % "3.9.1"
   )
   .settings(
-    addSbtPlugin("org.wartremover"   % "sbt-wartremover"  % "2.4.7"),
+    addSbtPlugin("org.wartremover"   % "sbt-wartremover"  % "2.4.8"),
     addSbtPlugin("io.spray"          % "sbt-revolver"     % "0.9.1"),
     addSbtPlugin("com.dwijnand"      % "sbt-reloadquick"  % "1.0.0"),
     addSbtPlugin("com.timushev.sbt"  % "sbt-updates"      % "0.5.0"),

--- a/common/src/main/scala/com/softwaremill/SbtSoftwareMillCommon.scala
+++ b/common/src/main/scala/com/softwaremill/SbtSoftwareMillCommon.scala
@@ -99,6 +99,16 @@ object SbtSoftwareMillCommon extends AutoPlugin {
       )
     }
 
+    val filterTestCompileScalacOptions = { options: Seq[String] =>
+      options.filterNot(
+        Set(
+          "-Ywarn-value-discard",
+          "-Ywarn-numeric-widen",
+          "-Ywarn-dead-code"
+        )
+      )
+    }
+
     lazy val commonSmlBuildSettings = Seq(
       isDotty := scalaVersion.value.startsWith("0."),
       outputStrategy := Some(StdoutOutput),
@@ -127,6 +137,8 @@ object SbtSoftwareMillCommon extends AutoPlugin {
       scalacOptions ++= scalacOptionsFor(scalaVersion.value),
       scalacOptions.in(Compile, console) ~= filterConsoleScalacOptions,
       scalacOptions.in(Test, console) ~= filterConsoleScalacOptions,
+      scalacOptions.in(Test, compile) ~= filterTestCompileScalacOptions,
+      scalacOptions.in(IntegrationTest, compile) ~= filterTestCompileScalacOptions,
       // silence transitive eviction warnings
       evictionWarningOptions in update := EvictionWarningOptions.default
         .withWarnTransitiveEvictions(false)

--- a/common/src/main/scala/com/softwaremill/SbtSoftwareMillCommon.scala
+++ b/common/src/main/scala/com/softwaremill/SbtSoftwareMillCommon.scala
@@ -102,7 +102,6 @@ object SbtSoftwareMillCommon extends AutoPlugin {
     val filterTestCompileScalacOptions = { options: Seq[String] =>
       options.filterNot(
         Set(
-          "-Ywarn-value-discard",
           "-Ywarn-numeric-widen",
           "-Ywarn-dead-code"
         )

--- a/common/src/sbt-test/sbt-softwaremill/simple/build.sbt
+++ b/common/src/sbt-test/sbt-softwaremill/simple/build.sbt
@@ -1,4 +1,4 @@
-crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.0")
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.2")
 
 scalacOptions += "-Xfatal-warnings"
 

--- a/extra/src/main/scala/com/softwaremill/SbtSoftwareMillExtra.scala
+++ b/extra/src/main/scala/com/softwaremill/SbtSoftwareMillExtra.scala
@@ -26,6 +26,8 @@ object SbtSoftwareMillExtra extends AutoPlugin {
       libraryDependencies += "com.lihaoyi" %% "acyclic" % acyclicVersion.value % "provided",
       autoCompilerPlugins := true,
       scalacOptions += "-P:acyclic:force",
+      (scalacOptions in Test) += "-P:acyclic:force",
+      (scalacOptions in IntegrationTest) += "-P:acyclic:force",
       libraryDependencies += compilerPlugin("com.lihaoyi" %% "acyclic" % acyclicVersion.value)
     )
 

--- a/extra/src/main/scala/com/softwaremill/SbtSoftwareMillExtra.scala
+++ b/extra/src/main/scala/com/softwaremill/SbtSoftwareMillExtra.scala
@@ -2,7 +2,8 @@ package com.softwaremill
 
 import sbt._
 import Keys._
-import wartremover.{wartremoverWarnings, Wart, Warts}
+import wartremover.{Wart, Warts}
+import wartremover.WartRemover.autoImport._
 import net.vonbuchholtz.sbt.dependencycheck.DependencyCheckPlugin
 
 object SbtSoftwareMillExtra extends AutoPlugin {
@@ -64,9 +65,7 @@ object SbtSoftwareMillExtra extends AutoPlugin {
     lazy val splainSettings = Seq(
       libraryDependencies ++= {
         val splainVersion = CrossVersion.partialVersion(scalaVersion.value) match {
-          // splain has dropped support of Scala 2.10 with version 0.3.1
-          // last version supporting Scala 2.10 is splain 0.2.10
-          case Some((2, v)) if v >= 11 => Some("0.4.1")
+          case Some((2, v)) if v >= 11 => Some("0.5.6")
           case Some((2, v)) if v == 11 => Some("0.2.10")
           case _ => None // dotty
         }


### PR DESCRIPTION
* This PR removes following flags:
```
       "-Ywarn-value-discard",
        "-Ywarn-numeric-widen",
        "-Ywarn-dead-code"
```
from test scopes, as they have been reported to be quite annoying in a few projects.

* Another update is enabling acyclic for test scopes

* Finally, some dependencies are bumped (especially splain, now allows switching to Scala 2.13.2)