### PR TITLE
Update wartremover to 2.4.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val extra = project
     libraryDependencies += "com.github.pathikrit" %% "better-files" % "3.9.1"
   )
   .settings(
-    addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.8"),
+    addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.9"),
     addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1"),
     addSbtPlugin("com.dwijnand" % "sbt-reloadquick" % "1.0.0"),
     addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0"),


### PR DESCRIPTION
wartremover version 2.4.9 is the first one to support scala 2.13.3. Otherwise one has to add `addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.9")` to their own `build.sbt` in addition to *sbt-softwaremill* plugins in order to compile for scala 2.13.3.