### PR TITLE
Fix splain resolve on 2.12.12 by updating to 0.5.7

### DIFF
--- a/extra/src/main/scala/com/softwaremill/SbtSoftwareMillExtra.scala
+++ b/extra/src/main/scala/com/softwaremill/SbtSoftwareMillExtra.scala
@@ -67,7 +67,7 @@ object SbtSoftwareMillExtra extends AutoPlugin {
     lazy val splainSettings = Seq(
       libraryDependencies ++= {
         val splainVersion = CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((2, v)) if v >= 11 => Some("0.5.6")
+          case Some((2, v)) if v >= 11 => Some("0.5.7")
           case Some((2, v)) if v == 11 => Some("0.2.10")
           case _ => None // dotty
         }


### PR DESCRIPTION
Splain 0.5.6 does not have a released artifact for 2.12.12, but 0.5.7 does.

On 0.5.6 builds fail with:

`sbt.librarymanagement.ResolveException: Error downloading io.tryp:splain_2.12.12:0.5.6`